### PR TITLE
fix startup for accel

### DIFF
--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -32,26 +32,22 @@ int ICM42688::begin() {
     // setting the I2C clock
     _i2c->setClock(_i2cRate);
   }
-  // select clock source to gyro
-  if(writeRegister(INTF_CONFIG1,CLOCK_SEL_PLL) < 0) {
-    return -1;
-  }
+
   // reset the ICM42688
-  writeRegister(DEVICE_CONFIG,PWR_RESET);
+  writeRegister(DEVICE_CONFIG, 0x01);
   // wait for ICM42688 to come back up
   delay(1);
-  // select clock source to gyro
-  if(writeRegister(INTF_CONFIG1,CLOCK_SEL_PLL) < 0) {
-    return -2;
-  }
+
   // check the WHO AM I byte, expected value is 0x47 (decimal 71)
   if(whoAmI() != 71) {
     return -3;
   }
-  // enable accelerometer and gyro
-  if(writeRegister(PWR_MGMT0,SEN_ENABLE) < 0) {
+
+  // turn on accel and gyro in Low Noise (LN) Mode
+  if(writeRegister(PWR_MGMT0, 0x0F) < 0) {
     return -4;
   }
+
   // setting accel range to 16G and 32kHz as default
   if(writeRegister(ACCEL_CONFIG0,ACCEL_FS_SEL_16G | ACCEL_ODR_32KHZ) < 0) {
     return -5;

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -125,10 +125,10 @@ class ICM42688{
     const uint8_t TEMP_OUT = 0x1D;
 
     const uint8_t ACCEL_CONFIG0 = 0x50;
-    const uint8_t ACCEL_FS_SEL_2G = 0x80; // TODO: 0x60 in datasheet
-    const uint8_t ACCEL_FS_SEL_4G = 0x60; // TODO: 0x40 in datasheet
-    const uint8_t ACCEL_FS_SEL_8G = 0x40; // TODO: 0x20 in datasheet
-    const uint8_t ACCEL_FS_SEL_16G = 0x20; // TODO: 0x00 in datasheet
+    const uint8_t ACCEL_FS_SEL_2G = 0x60;
+    const uint8_t ACCEL_FS_SEL_4G = 0x40;
+    const uint8_t ACCEL_FS_SEL_8G = 0x20;
+    const uint8_t ACCEL_FS_SEL_16G = 0x00;
     const uint8_t ACCEL_ODR_32KHZ = 0x01;
     const uint8_t ACCEL_ODR_16KHZ = 0x02;
     const uint8_t ACCEL_ODR_8KHZ = 0x03;
@@ -176,11 +176,8 @@ class ICM42688{
     const uint8_t INT_STATUS = 0x2D;
 
     const uint8_t DEVICE_CONFIG = 0x11;
-    const uint8_t PWR_RESET = 0x80;
     const uint8_t INTF_CONFIG1 = 0x4D;
-    const uint8_t CLOCK_SEL_PLL = 0x01;
     const uint8_t PWR_MGMT0 = 0x4E;
-    const uint8_t SEN_ENABLE = 0x0F;
 
     const uint8_t WHO_AM_I = 0x75;
     const uint8_t FIFO_EN = 0x23;


### PR DESCRIPTION
- `PWR_RESET` was set to `0x80` but should be `0x01` for the ICM 42688-p. The bit at `0x80` in the register is reserved. At best, this was not reseting the device when requested, at worst it was creating undefined behavior / setting bits in other registers (maybe related to #4 ?)
- `CLOCK_SEL_PLL` was meant to be selecting the PLL for gyro, which is the default. However, `CLOCK_SEL_PLL` was set as `0x01`, which was clearing the bit for `ACCEL_LP_CLK_SEL`, thus selecting the lower quality _Wake Up_ clock. Before this change, the accel was not returning 9.8 when sitting on the table, but rather a value around 7.
- ACCEL_FS_SEL bits were backwards (as noted in the code).

With these changes I am now getting valid accel measurements.