### PR TITLE
Update registers.h for Arduino compatibility

### DIFF
--- a/src/registers.h
+++ b/src/registers.h
@@ -1,7 +1,7 @@
 #ifndef ICM42688_REGISTERS_H_
 #define ICM42688_REGISTERS_H_
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace ICM42688reg {
 


### PR DESCRIPTION
Replacing \<cstdint\> with \<stdint.h\> for Arduino compatibility.