### PR TITLE
Compute and set Offsets on the the chip registers (User Bank 4), with Raw reading, Notch Filter

### DIFF
--- a/examples/SetUserOffsets/SetUserOffsets.ino
+++ b/examples/SetUserOffsets/SetUserOffsets.ino
@@ -1,0 +1,86 @@
+#include <Arduino.h>
+#include "ICM42688.h"
+
+
+ICM42688 imu(SPI, 5);
+volatile bool dataReady = false;
+
+
+// prototypes:
+void setImuFlag();
+
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial) {}
+  Serial.println("program starts...");
+
+  int status = imu.begin();
+  if (status < 0) {
+    Serial.println("IMU initialization unsuccessful");
+    Serial.println("Check IMU wiring or try cycling power");
+    Serial.print("Status: ");
+    Serial.println(status);
+    while(1) {}
+  }
+
+  // attaching the interrupt to microcontroller pin 
+  pinMode(22, INPUT);
+  attachInterrupt(22, setImuFlag, RISING);
+  // configure ICM42688
+    // set output data rate to 200 Hz
+    imu.setAccelODR(ICM42688::odr50);
+    imu.setGyroODR(ICM42688::odr50);
+    // set Scale
+    imu.setAccelFS(ICM42688::AccelFS::gpm16);
+    imu.setGyroFS(ICM42688::GyroFS::dps2000);
+    //disable filters
+    imu.setFilters(false, false);
+    // enabling the data ready interrupt
+    imu.enableDataReadyInterrupt(); 
+
+  
+  // Place the IMU in its calibration position, do not induce any motion/vibration
+  imu.computeOffsets();  //note, Full scale used are dps2000 for gyro and gm2 for accelerometers. user full scale are restored after offsets
+  imu.setAllOffsets();
+  Serial.println("raw Bias:");
+  Serial.print(imu.rawBiasAccX());Serial.print("\t");
+  Serial.print(imu.rawBiasAccY());Serial.print("\t");
+  Serial.print(imu.rawBiasAccZ());Serial.print("\t");
+  Serial.print(imu.rawBiasGyrX());Serial.print("\t");
+  Serial.print(imu.rawBiasGyrY());Serial.print("\t");
+  Serial.print(imu.rawBiasGyrZ());Serial.print("\t");
+  Serial.println("");
+  delay(1000);
+  Serial.println("End of Setup");
+
+}
+
+void loop() {
+  if (!dataReady) return;
+    dataReady = false;
+    // read the sensor
+    imu.getRawAGT();
+    //read raw data
+    int16_t AccXraw = imu.rawAccX();
+    int16_t AccYraw = imu.rawAccY();
+    int16_t AccZraw = imu.rawAccZ();
+    int16_t GyrXraw = imu.rawGyrX();
+    int16_t GyrYraw = imu.rawGyrY();
+    int16_t GyrZraw = imu.rawGyrZ();
+    int16_t Tempraw = imu.rawTemp();
+
+    Serial.print(AccXraw);Serial.print("\t");
+    Serial.print(AccYraw);Serial.print("\t");
+    Serial.print(AccZraw);Serial.print("\t");
+    Serial.print(GyrXraw);Serial.print("\t");
+    Serial.print(GyrYraw);Serial.print("\t");
+    Serial.print(GyrZraw);Serial.print("\t");
+    Serial.print(Tempraw);Serial.print("\t");
+    Serial.println("");
+     delay(50);
+}
+
+
+// Interrupt function
+void IRAM_ATTR setImuFlag(){dataReady = true;}

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -218,19 +218,7 @@ int ICM42688::disableDataReadyInterrupt() {
 
 /* reads the most current data from ICM42688 and stores in buffer */
 int ICM42688::getAGT() {
-  getRawAGT();
-
-
-
-  // _useSPIHS = true; // use the high speed SPI for data readout
-  // // grab the data from the ICM42688
-  // if (readRegisters(UB0_REG_TEMP_DATA1, 14, _buffer) < 0) return -1;
-
-  // combine bytes into 16 bit values
-  // int16_t rawMeas[7]; // temp, accel xyz, gyro xyz
-  // for (size_t i=0; i<7; i++) {
-  //   rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
-  // }
+  if(getRawAGT()<0) return -1;
 
   _t = (static_cast<float>(_rawT) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
 
@@ -634,9 +622,27 @@ uint8_t ICM42688::whoAmI() {
 
 
 
-/* 
+/* get Raw Bias (Offsets)*/
+int getRawBias(){
+  _rawBia
+}
 
 
+
+/* getrawGyroBias*/
+
+
+
+
+/* Set Gyro Offsets*/
+int setGyrOffset(){}
+
+/* Set Accel Offsets*/
+int setAccOffset(){}
+
+
+/* Selftest*/
+ int selfTest(){}
 
 
 

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -232,15 +232,15 @@ int ICM42688::getAGT() {
   //   rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
   // }
 
-  _t = (static_cast<float>(_rawMeas[0]) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
+  _t = (static_cast<float>(_rawT) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
 
-  _acc[0] = ((_rawMeas[1] * _accelScale) - _accB[0]) * _accS[0];
-  _acc[1] = ((_rawMeas[2] * _accelScale) - _accB[1]) * _accS[1];
-  _acc[2] = ((_rawMeas[3] * _accelScale) - _accB[2]) * _accS[2];
+  _acc[0] = ((_rawAcc[0] * _accelScale) - _accB[0]) * _accS[0];
+  _acc[1] = ((_rawAcc[1] * _accelScale) - _accB[1]) * _accS[1];
+  _acc[2] = ((_rawAcc[2] * _accelScale) - _accB[2]) * _accS[2];
 
-  _gyr[0] = (_rawMeas[4] * _gyroScale) - _gyrB[0];
-  _gyr[1] = (_rawMeas[5] * _gyroScale) - _gyrB[1];
-  _gyr[2] = (_rawMeas[6] * _gyroScale) - _gyrB[2];
+  _gyr[0] = (_rawGyr[0] * _gyroScale) - _gyrB[0];
+  _gyr[1] = (_rawGyr[1] * _gyroScale) - _gyrB[1];
+  _gyr[2] = (_rawGyr[2] * _gyroScale) - _gyrB[2];
 
   return 1;
 }

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -223,22 +223,50 @@ int ICM42688::getAGT() {
   if (readRegisters(UB0_REG_TEMP_DATA1, 14, _buffer) < 0) return -1;
 
   // combine bytes into 16 bit values
+  int16_t rawMeas[7]; // temp, accel xyz, gyro xyz
   for (size_t i=0; i<7; i++) {
-    _rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
+    rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
   }
 
-  _t = (static_cast<float>(_rawMeas[0]) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
+  _t = (static_cast<float>(rawMeas[0]) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
 
-  _acc[0] = ((_rawMeas[1] * _accelScale) - _accB[0]) * _accS[0];
-  _acc[1] = ((_rawMeas[2] * _accelScale) - _accB[1]) * _accS[1];
-  _acc[2] = ((_rawMeas[3] * _accelScale) - _accB[2]) * _accS[2];
+  _acc[0] = ((rawMeas[1] * _accelScale) - _accB[0]) * _accS[0];
+  _acc[1] = ((rawMeas[2] * _accelScale) - _accB[1]) * _accS[1];
+  _acc[2] = ((rawMeas[3] * _accelScale) - _accB[2]) * _accS[2];
 
-  _gyr[0] = (_rawMeas[4] * _gyroScale) - _gyrB[0];
-  _gyr[1] = (_rawMeas[5] * _gyroScale) - _gyrB[1];
-  _gyr[2] = (_rawMeas[6] * _gyroScale) - _gyrB[2];
+  _gyr[0] = (rawMeas[4] * _gyroScale) - _gyrB[0];
+  _gyr[1] = (rawMeas[5] * _gyroScale) - _gyrB[1];
+  _gyr[2] = (rawMeas[6] * _gyroScale) - _gyrB[2];
 
   return 1;
 }
+
+
+int ICM42688::getRawAGT() {
+  _useSPIHS = true; // use the high speed SPI for data readout
+  // grab the data from the ICM42688
+  if (readRegisters(UB0_REG_TEMP_DATA1, 14, _buffer) < 0) return -1;
+
+  // combine bytes into 16 bit values
+  int16_t rawMeas[7]; // temp, accel xyz, gyro xyz
+  for (size_t i=0; i<7; i++) {
+    rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
+  }
+
+  _rawT = rawMeas[0];
+  _rawAcc[0] = rawMeas[1] ;
+  _rawAcc[1] = rawMeas[2] ;
+  _rawAcc[2] = rawMeas[3] ;
+  _rawGyr[0] = rawMeas[4] ;
+  _rawGyr[1] = rawMeas[5] ;
+  _rawGyr[2] = rawMeas[6] ;
+
+  return 1;
+}
+
+
+
+
 
 /* configures and enables the FIFO buffer  */
 int ICM42688_FIFO::enableFifo(bool accel,bool gyro,bool temp) {
@@ -503,43 +531,6 @@ void ICM42688::setAccelCalZ(float bias,float scaleFactor) {
   _accB[2] = bias;
   _accS[2] = scaleFactor;
 }
-
-/* returns the accelerometer measurement in the x direction, raw 16-bit integer */
-int16_t ICM42688::getAccelX_count()
-{
-    return _rawMeas[1];
-}
-
-/* returns the accelerometer measurement in the y direction, raw 16-bit integer */
-int16_t ICM42688::getAccelY_count()
-{
-    return _rawMeas[2];
-}
-
-/* returns the accelerometer measurement in the z direction, raw 16-bit integer */
-int16_t ICM42688::getAccelZ_count()
-{
-    return _rawMeas[3];
-}
-
-/* returns the gyroscople measurement in the x direction, raw 16-bit integer */
-int16_t ICM42688::getGyroX_count()
-{
-    return _rawMeas[4];
-}
-
-/* returns the gyroscople measurement in the y direction, raw 16-bit integer */
-int16_t ICM42688::getGyroY_count()
-{
-    return _rawMeas[5];
-}
-
-/* returns the gyroscople measurement in the z direction, raw 16-bit integer */
-int16_t ICM42688::getGyroZ_count()
-{
-    return _rawMeas[6];
-}
-
 
 /* writes a byte to ICM42688 register given a register address and data */
 int ICM42688::writeRegister(uint8_t subAddress, uint8_t data) {

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -624,12 +624,28 @@ uint8_t ICM42688::whoAmI() {
 
 /* get Raw Bias (Offsets)*/
 int getRawBias(){
-  _rawBia
+  _rawBias[0] = 0; 
+  _rawBias[1] = 0;
+  _rawBias[2] = 0;
+  _rawBias[3] = 0;
+  _rawBias[4] = 0;
+  _rawBias[5] = 0;
+
+  
+  for (size_t i=0; i < NUM_CALIB_SAMPLES; i++) {
+    getRawAGT();
+    _rawAccBias[0] += _rawAcc[0]
+    _rawAccBias[1] += _rawAcc[1]
+    _rawAccBias[2] += _rawAcc[2]
+    _rawGyrBias[0] += _rawGyr[0]
+    _rawGyrBias[1] += _rawGyr[1]
+    _rawGyrBias[2] += _rawGyr[2]
+    delay(50);
+  }
+  ///#TODO - do the average and cast to int32
+  return 1;
 }
 
-
-
-/* getrawGyroBias*/
 
 
 

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -218,25 +218,29 @@ int ICM42688::disableDataReadyInterrupt() {
 
 /* reads the most current data from ICM42688 and stores in buffer */
 int ICM42688::getAGT() {
-  _useSPIHS = true; // use the high speed SPI for data readout
-  // grab the data from the ICM42688
-  if (readRegisters(UB0_REG_TEMP_DATA1, 14, _buffer) < 0) return -1;
+  getRawAGT();
+
+
+
+  // _useSPIHS = true; // use the high speed SPI for data readout
+  // // grab the data from the ICM42688
+  // if (readRegisters(UB0_REG_TEMP_DATA1, 14, _buffer) < 0) return -1;
 
   // combine bytes into 16 bit values
-  int16_t rawMeas[7]; // temp, accel xyz, gyro xyz
-  for (size_t i=0; i<7; i++) {
-    rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
-  }
+  // int16_t rawMeas[7]; // temp, accel xyz, gyro xyz
+  // for (size_t i=0; i<7; i++) {
+  //   rawMeas[i] = ((int16_t)_buffer[i*2] << 8) | _buffer[i*2+1];
+  // }
 
-  _t = (static_cast<float>(rawMeas[0]) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
+  _t = (static_cast<float>(_rawMeas[0]) / TEMP_DATA_REG_SCALE) + TEMP_OFFSET;
 
-  _acc[0] = ((rawMeas[1] * _accelScale) - _accB[0]) * _accS[0];
-  _acc[1] = ((rawMeas[2] * _accelScale) - _accB[1]) * _accS[1];
-  _acc[2] = ((rawMeas[3] * _accelScale) - _accB[2]) * _accS[2];
+  _acc[0] = ((_rawMeas[1] * _accelScale) - _accB[0]) * _accS[0];
+  _acc[1] = ((_rawMeas[2] * _accelScale) - _accB[1]) * _accS[1];
+  _acc[2] = ((_rawMeas[3] * _accelScale) - _accB[2]) * _accS[2];
 
-  _gyr[0] = (rawMeas[4] * _gyroScale) - _gyrB[0];
-  _gyr[1] = (rawMeas[5] * _gyroScale) - _gyrB[1];
-  _gyr[2] = (rawMeas[6] * _gyroScale) - _gyrB[2];
+  _gyr[0] = (_rawMeas[4] * _gyroScale) - _gyrB[0];
+  _gyr[1] = (_rawMeas[5] * _gyroScale) - _gyrB[1];
+  _gyr[2] = (_rawMeas[6] * _gyroScale) - _gyrB[2];
 
   return 1;
 }
@@ -627,3 +631,36 @@ uint8_t ICM42688::whoAmI() {
   // return the register value
   return _buffer[0];
 }
+
+
+
+/* 
+
+
+
+
+
+//#DONE
+/*
+raw data reading
+*/
+
+//#TODO
+/*
+DRStatus
+Seld test
+Offset Bias
+
+WakeOnMotion
+ApexStatus   => INT_STATUS2 and INT_STATUS3
+8.1 APEX ODR SUPPORT
+8.2 DMP POWER SAVE MODE
+8.3 PEDOMETER PROGRAMMING
+8.4 TILT DETECTION PROGRAMMING
+8.5 RAISE TO WAKE/SLEEP PROGRAMMING
+8.6 TAP DETECTION PROGRAMMING
+8.7 WAKE ON MOTION PROGRAMMING
+8.8 SIGNIFICANT MOTION DETECTION PROGRAMMING  p47
+
+
+*/

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -651,14 +651,14 @@ int getRawBias(){
 
 
 /* Set Gyro Offsets*/
-int setGyrOffset(){}
+int setGyrOffset(){return 1}
 
 /* Set Accel Offsets*/
-int setAccOffset(){}
+int setAccOffset(){return 1}
 
 
 /* Selftest*/
- int selfTest(){}
+ int selfTest(){return 1}
 
 
 

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -130,6 +130,7 @@ class ICM42688
      * @return     ret < 0 if error
      */
     int getAGT();
+    int getRawAGT();
 
     /**
      * @brief      Get accelerometer data, per axis
@@ -156,12 +157,34 @@ class ICM42688
      */
     float temp() const { return _t; }
 
-    int16_t getAccelX_count();
-    int16_t getAccelY_count();
-    int16_t getAccelZ_count();
-    int16_t getGyroX_count();
-    int16_t getGyroY_count();
-    int16_t getGyroZ_count();
+
+    /**
+     * @brief      Get accelerometer Raw data, per axis
+     *
+     * @return     Acceleration in bytes
+     */
+    int16_t rawAccX() const { return _rawAcc[0]; }
+    int16_t rawAccY() const { return _rawAcc[1]; }
+    int16_t rawAccZ() const { return _rawAcc[2]; }
+
+    /**
+     * @brief      Get gyro raw data, per axis
+     *
+     * @return     Angular velocity in bytes
+     */
+    int16_t rawGyrX() const { return _rawGyr[0]; }
+    int16_t rawGyrY() const { return _rawGyr[1]; }
+    int16_t rawGyrZ() const { return _rawGyr[2]; }
+
+    /**
+     * @brief      Get raw temperature of gyro die
+     *
+     * @return     Temperature in bytes
+     */
+    int16_t rawTemp() const { return _rawT; }
+
+
+
 
     int calibrateGyro();
     float getGyroBiasX();
@@ -187,8 +210,6 @@ class ICM42688
     static constexpr uint32_t I2C_CLK = 400000; // 400 kHz
     size_t _numBytes = 0; // number of bytes received from I2C
 
-    int16_t _rawMeas[7]; // temp, accel xyz, gyro xyz
-
     ///\brief SPI Communication
     SPIClass *_spi = {};
     uint8_t _csPin = 0;
@@ -204,6 +225,10 @@ class ICM42688
     float _t = 0.0f;
     float _acc[3] = {};
     float _gyr[3] = {};
+
+    int16_t _rawT = 0;
+    int16_t _rawAcc[3]={};
+    int16_t _rawGyr[3]={};
 
     ///\brief Full scale resolution factors
     float _accelScale = 0.0f;

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -183,6 +183,11 @@ class ICM42688
      */
     int16_t rawTemp() const { return _rawT; }
 
+    
+    int getRawBias();
+    int setGyrOffset();
+    int setAccOffset();
+    int selfTest();
 
 
 
@@ -229,6 +234,12 @@ class ICM42688
     int16_t _rawT = 0;
     int16_t _rawAcc[3]={};
     int16_t _rawGyr[3]={};
+
+
+    ///\brief Raw Gyro and Accelero Bias
+    int32_t _rawAccBias[3]={0,0,0};
+    int32_t _rawGyrBias[3] = {0,0,0};
+
 
     ///\brief Full scale resolution factors
     float _accelScale = 0.0f;
@@ -294,6 +305,10 @@ class ICM42688
      * @return     Value of WHO_AM_I register
      */
     uint8_t whoAmI();
+
+
+
+    void selfTest(int16_t * accelDiff, int16_t * gyroDiff, float * ratio);
 };
 
 class ICM42688_FIFO: public ICM42688 {

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -45,6 +45,23 @@ class ICM42688
       odr500 = 0x0F,
     };
 
+    enum GyroNFBWsel : uint8_t{
+        nfBW1449Hz = 0x00,
+        nfBW680z = 0x01,
+        nfBW329Hz = 0x02,
+        nfBW162Hz = 0x03,
+        nfBW80Hz = 0x04,
+        nfBW40Hz = 0x05,
+        nfBW20Hz = 0x06,
+        nfBW10Hz = 0x07,
+    };
+
+    enum UIFiltOrd : uint8_t{  
+      first_order  = 0x00,
+      second_order = 0x01,
+      third_order  = 0x02,
+    };
+
     /**
      * @brief      Constructor for I2C communication
      *
@@ -76,7 +93,7 @@ class ICM42688
      * @return     ret < 0 if error
      */
     int setAccelFS(AccelFS fssel);
-
+    int getAccelFS();
     /**
      * @brief      Sets the full scale range for the gyro
      *
@@ -85,7 +102,7 @@ class ICM42688
      * @return     ret < 0 if error
      */
     int setGyroFS(GyroFS fssel);
-
+    int getGyroFS();
     /**
      * @brief      Set the ODR for accelerometer
      *
@@ -94,6 +111,7 @@ class ICM42688
      * @return     ret < 0 if error
      */
     int setAccelODR(ODR odr);
+    int getAccelODR();
 
     /**
      * @brief      Set the ODR for gyro
@@ -103,6 +121,7 @@ class ICM42688
      * @return     ret < 0 if error
      */
     int setGyroODR(ODR odr);
+    int getGyroODR();
 
     int setFilters(bool gyroFilters, bool accFilters);
 
@@ -184,12 +203,36 @@ class ICM42688
     int16_t rawTemp() const { return _rawT; }
 
     
-    int getRawBias();
-    int setGyrOffset();
-    int setAccOffset();
+    /**
+     * @brief      Get raw temperature of gyro die
+     *
+     * @return     Temperature in bytes
+     */
+    int32_t rawBiasAccX() const{ return _rawAccBias[0];}
+    int32_t rawBiasAccY() const{ return _rawAccBias[1];}
+    int32_t rawBiasAccZ() const{ return _rawAccBias[2];}
+    int32_t rawBiasGyrX() const{ return _rawGyrBias[0];}
+    int32_t rawBiasGyrY() const{ return _rawGyrBias[1];}
+    int32_t rawBiasGyrZ() const{ return _rawGyrBias[2];}
+
+
+
+    
+    
+    int computeOffsets();
+    int setAllOffsets();                   //Set all Offsets computed
+    int setGyrXOffset(int16_t gyrXoffset); //#TODO add the getOffset function
+    int setGyrYOffset(int16_t gyrYoffset);
+    int setGyrZOffset(int16_t gyrZoffset);
+    int setAccXOffset(int16_t accXoffset);
+    int setAccYOffset(int16_t accYoffset);
+    int setAccZOffset(int16_t accZoffset);
+    float getAccelRes();
+    float getGyroRes();
+    int setUIFilterBlock(UIFiltOrd gyroUIFiltOrder,UIFiltOrd accelUIFiltOrder);
+    int setGyroNotchFilter(float gyroNFfreq_x,float gyroNFfreq_y,float gyroNFfreq_z,GyroNFBWsel gyro_nf_bw);//
     int selfTest();
-
-
+    int testingFunction();
 
     int calibrateGyro();
     float getGyroBiasX();
@@ -239,6 +282,10 @@ class ICM42688
     ///\brief Raw Gyro and Accelero Bias
     int32_t _rawAccBias[3]={0,0,0};
     int32_t _rawGyrBias[3] = {0,0,0};
+
+    ///\brief Raw Gyro and Accelero Offsets
+    int16_t _AccOffset[3]={0,0,0};
+    int16_t _GyrOffset[3] = {0,0,0};
 
 
     ///\brief Full scale resolution factors
@@ -305,8 +352,6 @@ class ICM42688
      * @return     Value of WHO_AM_I register
      */
     uint8_t whoAmI();
-
-
 
     void selfTest(int16_t * accelDiff, int16_t * gyroDiff, float * ratio);
 };


### PR DESCRIPTION
Here are the main updates:
1) Raw reading getRawAGT(): necessary to compute offsets
2) Data reading getAGT(): use the rawReading, method. 
3) Added some definitions
4) Added get resolutions
5) Added compute Offsets: compute the offset to be put in the user bank register, this provide a simple calibration method
6) Added set offset methods: either setting all Offsets are once, or setting for each axis, gyro and accelerometer
7) Added an example on how to use the Offset methods. 
8) Notch filter settings, user should input the notch frequencies for each axis, and Bandwidth (untested) added enum for the bandwidth. (testing would require to stream data towards an analyzer and having a code to change the notch filter live)
 


