### PR TITLE
FIFO fixes per datasheet

### DIFF
--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -262,6 +262,14 @@ int ICM42688_FIFO::enableFifo(bool accel,bool gyro,bool temp) {
   return 1;
 }
 
+/* Start streaming, required to read after enableFifo() under most sensor configurations */
+int ICM42688_FIFO::streamToFifo(){
+  if(writeRegister(ICM42688reg::UB0_REG_FIFO_CONFIG, 1 << 6); < 0) {
+    return -2;
+  }
+  return 1;
+}
+
 /* reads data from the ICM42688 FIFO and stores in buffer
   High-resolution mode not yet supported */
 int ICM42688_FIFO::readFifo() {

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -275,6 +275,7 @@ class ICM42688_FIFO: public ICM42688 {
   public:
     using ICM42688::ICM42688;
     int enableFifo(bool accel,bool gyro,bool temp);
+    int streamToFifo();
     int readFifo();
     void getFifoAccelX_mss(size_t *size,float* data);
     void getFifoAccelY_mss(size_t *size,float* data);

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -234,7 +234,7 @@ class ICM42688
 
     uint8_t _bank = 0; ///< current user bank
 
-    const uint8_t FIFO_EN = 0x23;
+    const uint8_t FIFO_EN = 0x5F;
     const uint8_t FIFO_TEMP_EN = 0x04;
     const uint8_t FIFO_GYRO = 0x02;
     const uint8_t FIFO_ACCEL = 0x01;

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -288,6 +288,8 @@ class ICM42688_FIFO: public ICM42688 {
     bool _enFifoAccel = false;
     bool _enFifoGyro = false;
     bool _enFifoTemp = false;
+    bool _enFifoTimestamp = false;
+    bool _enFifoHeader = false;
     size_t _fifoSize = 0;
     size_t _fifoFrameSize = 0;
     float _axFifo[85] = {};


### PR DESCRIPTION
## Part 1: [35fcc48]
*Bug*: FIFO_EN had the old value (0x23) from ICM20689
*Fix*: updated per 42688 datasheet

## Part 2 [16486a2, 8dda68c]
### Context: 
There are only four valid packet structures which the ICM42688 FIFO may emit ([datasheet](https://invensense.tdk.com/wp-content/uploads/2020/04/ds-000347_icm-42688-p-datasheet.pdf) section 6.1):
![image](https://github.com/finani/ICM42688/assets/89624368/a95a528a-e17d-48f3-b5e9-fcb51dc1ae06)

**Note:** Structure 3 and 4 are the only two which pass both accelerometer and gyroscope data, the only difference being that structure 4 adds high-resolution (16 -> 20-bit for accel/gyro, 8 -> 16 for temp). This library does not yet support the high-resolution mode in general and adding support will require several changes in data organization and function signatures. Accordingly, if both gyroscope and accelerometer data are expected, the subsequent code assumes Structure 3. 

*Bug*:
FIFO packets were being read as if the structure could be any subsequence from [6 Byte Accel, 2 Byte Temp, 6 Byte Gyro]. This was not valid as:
-  temperature is the guaranteed last sensor
-  this does not account for the header 
- if both accelerometer and gyroscope are enabled, there will be a 2-byte timestamp

*Fix 1*:
ReadFifo now accounts for the header byte and correctly orders temperature after accelerometer and/or gyro 
*Fix 2*:
Calling enableFifo now sets internal parameters forcing adherence to the best fitting of the valid Packet Structures 1-3 (cannot support Packet 4 as there is no high-resolution argument)

*Optimizations*:
Precalculate numFrames and data indices within each packet once per FIFO read. The current method performed the same static calculation every packet. This is redundant unless the structure is calculated by each packet's header, but this is not reliable as a header does not entirely convey the size.

## Part 3 [11d65de]
*Feature*: 
Added function to set the FIFO mode to "Stream-To-FIFO". In my testing, this was necessary to collect any data and appears to be required under most (if not all) sensor configurations.