### PR TITLE
added user definable SDA and SCL pin definitions & added definitions to examples

### DIFF
--- a/examples/Advanced_I2C/Advanced_I2C.ino
+++ b/examples/Advanced_I2C/Advanced_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus 0 with address 0x68
-ICM42688 IMU(Wire, 0x68);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
+ICM42688 IMU(Wire, 0x68, 21, 22);
 
 void setup() {
   // serial to display data
@@ -19,13 +19,13 @@ void setup() {
   }
 
   // setting the accelerometer full scale range to +/-8G
-  imu.setAccelFS(ICM42688::gpm8);
+  IMU.setAccelFS(ICM42688::gpm8);
   // setting the gyroscope full scale range to +/-500 deg/s
-  imu.setGyroFS(ICM42688::dps500);
+  IMU.setGyroFS(ICM42688::dps500);
   
   // set output data rate to 12.5 Hz
-  imu.setAccelODR(ICM42688::odr12_5);
-  imu.setGyroODR(ICM42688::odr12_5);
+  IMU.setAccelODR(ICM42688::odr12_5);
+  IMU.setGyroODR(ICM42688::odr12_5);
 
   Serial.println("ax,ay,az,gx,gy,gz,temp_C");
 }

--- a/examples/Basic_I2C/Basic_I2C.ino
+++ b/examples/Basic_I2C/Basic_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus 0 with address 0x68
-ICM42688 IMU(Wire, 0x68);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
+ICM42688 IMU(Wire, 0x68, 21, 22);
 
 void setup() {
   // serial to display data

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -1,14 +1,18 @@
+// 20240627 JB  Adding method to define custom I2C pins for SDA and SCL (was missing in ICM42688 1.1.0)
+
 #include "Arduino.h"
 #include "ICM42688.h"
 #include "registers.h"
 
 using namespace ICM42688reg;
 
-/* ICM42688 object, input the I2C bus and address */
-ICM42688::ICM42688(TwoWire &bus, uint8_t address) {
+/* ICM42688 object, input the I2C bus and address using SDA, SCL pins */
+ICM42688::ICM42688(TwoWire &bus, uint8_t address, uint8_t sda_in, uint8_t scl_in) {
   _i2c = &bus; // I2C bus
   _address = address; // I2C address
   _useSPI = false; // set to use I2C
+  SDA_PIN = sda_in; // set SDA to user defined pin
+  SCL_PIN = scl_in; // set SCL to user defined pin
 }
 
 /* ICM42688 object, input the SPI bus and chip select pin */
@@ -32,7 +36,7 @@ int ICM42688::begin() {
     _spi->begin();
   } else { // using I2C for communication
     // starting the I2C bus
-    _i2c->begin();
+    _i2c->begin(SDA_PIN,SCL_PIN);
     // setting the I2C clock
     _i2c->setClock(I2C_CLK);
   }

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -45,13 +45,18 @@ class ICM42688
       odr500 = 0x0F,
     };
 
+    uint8_t SDA_PIN = 21; // allow the user to define custom I2C SDA pin, othwerise default to 21
+    uint8_t SCL_PIN = 22; // allow the user to define custom I2C SCL pin, otherwise default to 22
+
     /**
      * @brief      Constructor for I2C communication
      *
      * @param      bus      I2C bus
      * @param[in]  address  Address of ICM 42688-p device
+     * @param[in]  SDA_PIN  GPIO pin to use for I2C SDA signal
+     * @param[in]  SCL_PIN  GPIO pin to use for I2C SCL signal
      */
-    ICM42688(TwoWire &bus, uint8_t address);
+    ICM42688(TwoWire &bus, uint8_t address, uint8_t SDA_PIN, uint8_t SCL_PIN);
 
     /**
      * @brief      Constructor for SPI communication


### PR DESCRIPTION
I have added the ability for users to specify their SDA and SCL pins for I2C communications since the ESP32C3 allows any GPIO to be I2C .. this makes the library far more robust

I have also corrected a minor issue with imu. in the advanced I2C example - I've corrected it to be IMU.