### PR TITLE
Added SDA and SCL pin definitions to allow for more versatility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ This library supports both I2C and SPI communication with the ICM42688. The *ICM
 ### I2C Object Declaration
 
 **ICM42688(TwoWire &bus, uint8_t address)**
-An ICM42688 object should be declared, specifying the I2C bus and ICM42688 I2C address. The ICM42688 I2C address will be 0x68 if the AD0 pin is grounded or 0x69 if the AD0 pin is pulled high. For example, the following code declares an ICM42688 object called *IMU* with an ICM42688 sensor located on I2C bus 0 with a sensor address of 0x68 (AD0 grounded).
+An ICM42688 object should be declared, specifying the I2C bus and ICM42688 I2C address. The ICM42688 I2C address will be 0x68 if the AD0 pin is grounded or 0x69 if the AD0 pin is pulled high. For example, the following code declares an ICM42688 object called *IMU* with an ICM42688 sensor located on I2C bus 0 with a sensor address of 0x68 (AD0 grounded). You should specify the SDA and SCL pins for your I2C connection (default for ESP32 is SDA=21, SCL=22, Arduino is SDA=18, SCL=19)
 
 ```C++
-ICM42688 IMU(Wire, 0x68);
+ICM42688 IMU(Wire, 0x68, SDA_PIN, SCL_PIN);
 ```
 
 ### SPI Object Declaration

--- a/examples/Advanced_I2C/Advanced_I2C.ino
+++ b/examples/Advanced_I2C/Advanced_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus 0 with address 0x68
-ICM42688 IMU(Wire, 0x68);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
+ICM42688 IMU(Wire, 0x68, 21, 22);
 
 void setup() {
   // serial to display data
@@ -19,13 +19,13 @@ void setup() {
   }
 
   // setting the accelerometer full scale range to +/-8G
-  imu.setAccelFS(ICM42688::gpm8);
+  IMU.setAccelFS(ICM42688::gpm8);
   // setting the gyroscope full scale range to +/-500 deg/s
-  imu.setGyroFS(ICM42688::dps500);
+  IMU.setGyroFS(ICM42688::dps500);
   
   // set output data rate to 12.5 Hz
-  imu.setAccelODR(ICM42688::odr12_5);
-  imu.setGyroODR(ICM42688::odr12_5);
+  IMU.setAccelODR(ICM42688::odr12_5);
+  IMU.setGyroODR(ICM42688::odr12_5);
 
   Serial.println("ax,ay,az,gx,gy,gz,temp_C");
 }

--- a/examples/Advanced_I2C/Advanced_I2C.ino
+++ b/examples/Advanced_I2C/Advanced_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
-ICM42688 IMU(Wire, 0x68, 21, 22);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22 (default for ESP32)
+ICM42688 IMU(Wire, 0x68, 21, 22);  // default for ESP32 = 21,22 and Arduino is 18,19
 
 void setup() {
   // serial to display data

--- a/examples/Basic_I2C/Basic_I2C.ino
+++ b/examples/Basic_I2C/Basic_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
-ICM42688 IMU(Wire, 0x68, 21, 22);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22 (default for ESP32)
+ICM42688 IMU(Wire, 0x68, 21, 22);  // default for ESP32 = 21,22 and Arduino is 18,19
 
 void setup() {
   // serial to display data

--- a/examples/Basic_I2C/Basic_I2C.ino
+++ b/examples/Basic_I2C/Basic_I2C.ino
@@ -1,7 +1,7 @@
 #include "ICM42688.h"
 
-// an ICM42688 object with the ICM42688 sensor on I2C bus 0 with address 0x68
-ICM42688 IMU(Wire, 0x68);
+// an ICM42688 object with the ICM42688 sensor on I2C bus with address 0x68 using SDA pin 21 and SCL pin 22
+ICM42688 IMU(Wire, 0x68, 21, 22);
 
 void setup() {
   // serial to display data

--- a/src/ICM42688.cpp
+++ b/src/ICM42688.cpp
@@ -1,14 +1,18 @@
+// 20240627 JB  Adding method to define custom I2C pins for SDA and SCL (was missing in ICM42688 1.1.0)
+
 #include "Arduino.h"
 #include "ICM42688.h"
 #include "registers.h"
 
 using namespace ICM42688reg;
 
-/* ICM42688 object, input the I2C bus and address */
-ICM42688::ICM42688(TwoWire &bus, uint8_t address) {
+/* ICM42688 object, input the I2C bus and address using SDA, SCL pins */
+ICM42688::ICM42688(TwoWire &bus, uint8_t address, uint8_t sda_in, uint8_t scl_in) {
   _i2c = &bus; // I2C bus
   _address = address; // I2C address
   _useSPI = false; // set to use I2C
+  SDA_PIN = sda_in; // set SDA to user defined pin
+  SCL_PIN = scl_in; // set SCL to user defined pin
 }
 
 /* ICM42688 object, input the SPI bus and chip select pin */
@@ -32,7 +36,7 @@ int ICM42688::begin() {
     _spi->begin();
   } else { // using I2C for communication
     // starting the I2C bus
-    _i2c->begin();
+    _i2c->begin(SDA_PIN,SCL_PIN);
     // setting the I2C clock
     _i2c->setClock(I2C_CLK);
   }

--- a/src/ICM42688.h
+++ b/src/ICM42688.h
@@ -45,13 +45,18 @@ class ICM42688
       odr500 = 0x0F,
     };
 
+    uint8_t SDA_PIN = 21; // allow the user to define custom I2C SDA pin, othwerise default to 21
+    uint8_t SCL_PIN = 22; // allow the user to define custom I2C SCL pin, otherwise default to 22
+
     /**
      * @brief      Constructor for I2C communication
      *
      * @param      bus      I2C bus
      * @param[in]  address  Address of ICM 42688-p device
+     * @param[in]  SDA_PIN  GPIO pin to use for I2C SDA signal
+     * @param[in]  SCL_PIN  GPIO pin to use for I2C SCL signal
      */
-    ICM42688(TwoWire &bus, uint8_t address);
+    ICM42688(TwoWire &bus, uint8_t address, uint8_t SDA_PIN, uint8_t SCL_PIN);
 
     /**
      * @brief      Constructor for SPI communication


### PR DESCRIPTION
I've added the requirement to specify the SDA and SCL pins because it adds a lot more flexibility to the library.
The default for ESP32 (21,22) and Arduino (18,19) are specified in the examples.

In the ESP32C3 series, any pin can easily be used for I2C and so it is best -not- to limit people to the default(s), rather encourage the user to define the I2C pins as part of instantiation. This makes the library more accessible to inexperienced users.